### PR TITLE
Add image option to have an ability to provide full image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ If you would like to reference the VPC elsewhere (such as in the [serverless-aur
             protocol: "HTTP" | "HTTPS";
             certificateArns?: string[]; // needed for https
         }>;
-        imageRepository: string;
-        imageTag?: string; //
+        image?: string; // full image name, REPOSITORY[:TAG]
+        imageRepository?: string; // image repository (used if image option is not provided)
+        imageTag?: string; // image tag (used if image option is not provided)
         priority?: number; // priority for routing, defaults to 1
         path?: string; // path the Load Balancer should send traffic to, defaults to '*'
         desiredCount?: number; // defaults to 1

--- a/src/options.ts
+++ b/src/options.ts
@@ -15,7 +15,8 @@ export interface IServiceOptions {
     port: number;
     entryPoint: string[];
     protocols: IServiceProtocolOptions[];
-    imageRepository: string;
+    image?: string;
+    imageRepository?: string;
     imageTag?: string;
     priority?: number; // priority for routing, defaults to 1
     path?: string; // path the LB should send traffic to, defaults '*' (everything)

--- a/src/resources/service.ts
+++ b/src/resources/service.ts
@@ -110,7 +110,7 @@ export class Service extends Resource<IServiceOptions> {
                             "Name": this.getName(NamePostFix.CONTAINER_NAME),
                             "Cpu": this.options.cpu,
                             "Memory": this.options.memory,
-                            "Image": `${this.options.imageRepository}:${this.options.name}-${this.options.imageTag}`,
+                            "Image": this.options.image || `${this.options.imageRepository}:${this.options.name}-${this.options.imageTag}`,
                             "EntryPoint": this.options.entryPoint,
                             "PortMappings": [
                                 {


### PR DESCRIPTION
Hey, @honerlaw . Thanks for the nice plugin, I found it really useful.
But please consider my PR to make Docker Image naming more obvious. Now the `name` option is going as part of docker image tag and it is not documented and moreover not applicable for all who uses this plugin. I just added a new `image` option which can be used as full image name instead of `imageRepository` and `imageTag`. if you have any concerns let's discuss.
Thank you.