### PR TITLE
Generate a more unique name for the loggroup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
       "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
       "dev": true
+    },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   "license": "MIT",
   "devDependencies": {
     "typescript": "^3.1.6"
+  },
+  "dependencies": {
+    "uuid": "^3.4.0"
   }
 }

--- a/src/resources/service.ts
+++ b/src/resources/service.ts
@@ -2,11 +2,12 @@ import {IServiceOptions, IServiceProtocolOptions} from "../options";
 import {Cluster} from "./cluster";
 import {NamePostFix, Resource} from "../resource";
 import {Protocol} from "./protocol";
+import * as uuid from 'uuid/v1';
 
 export class Service extends Resource<IServiceOptions> {
 
     private static readonly EXECUTION_ROLE_NAME: string = "ECSServiceExecutionRole";
-
+    private readonly logGroupName: string;
     private readonly cluster: Cluster;
     private readonly protocols: Protocol[];
 
@@ -24,6 +25,8 @@ export class Service extends Resource<IServiceOptions> {
         this.protocols = this.options.protocols.map((serviceProtocolOptions: IServiceProtocolOptions): any => {
             return new Protocol(cluster, this, stage, serviceProtocolOptions);
         });
+
+        this.logGroupName = `serverless-fargate-${options.name}-${stage}-${uuid()}`;
     }
 
     public generate(): any {
@@ -120,7 +123,7 @@ export class Service extends Resource<IServiceOptions> {
                             "LogConfiguration": {
                                 "LogDriver": "awslogs",
                                 "Options": {
-                                    "awslogs-group": `serverless-fargate-${this.options.name}-${this.stage}`,
+                                    "awslogs-group": this.logGroupName,
                                     "awslogs-region": {
                                         "Ref": "AWS::Region"
                                     },
@@ -221,7 +224,7 @@ export class Service extends Resource<IServiceOptions> {
             [this.getName(NamePostFix.LOG_GROUP)]: {
                 "Type": "AWS::Logs::LogGroup",
                 "Properties": {
-                    "LogGroupName": `serverless-fargate-${this.options.name}-${this.stage}`,
+                    "LogGroupName": this.logGroupName,
                     "RetentionInDays": 30
                 }
             }

--- a/src/resources/service.ts
+++ b/src/resources/service.ts
@@ -120,7 +120,7 @@ export class Service extends Resource<IServiceOptions> {
                             "LogConfiguration": {
                                 "LogDriver": "awslogs",
                                 "Options": {
-                                    "awslogs-group": `serverless-fargate-${this.stage}`,
+                                    "awslogs-group": `serverless-fargate-${this.options.name}-${this.stage}`,
                                     "awslogs-region": {
                                         "Ref": "AWS::Region"
                                     },
@@ -221,7 +221,7 @@ export class Service extends Resource<IServiceOptions> {
             [this.getName(NamePostFix.LOG_GROUP)]: {
                 "Type": "AWS::Logs::LogGroup",
                 "Properties": {
-                    "LogGroupName": `serverless-fargate-${this.stage}`,
+                    "LogGroupName": `serverless-fargate-${this.options.name}-${this.stage}`,
                     "RetentionInDays": 30
                 }
             }


### PR DESCRIPTION
To fix errors like these when using this plugin with multiple Fargate stacks.

`serverless-fargate-dev already exists in stack arn:aws:cloudformation:eu-north-1:*:stack/some-api-test-dev/...`

Max length for log group names are 512 so should be ok: https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_UntagLogGroup.html#API_UntagLogGroup_RequestSyntax
