### PR TITLE
Fixes and features to better support multi task cluster and routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@ bin/
 node_modules/
 .idea/
 .serverless/
-resources/
+/resources/
 *.js
 *.js.map

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ If you would like to reference the VPC elsewhere (such as in the [serverless-aur
       Customer: You
     };
     executionRoleArn?: string; // execution role for services, generated if not specified
+    disableELB?: boolean; //disable ELB creation and bindings, default to false. Usefull for long running processes
     vpc: {
         //if this options are specified it will create a VPC
         cidr: string;
@@ -93,6 +94,7 @@ custom:
     tags:
       customer: You
       owner: Me
+    disableELB: false
     services:
     - name: example-name
       cpu: 512

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ If you would like to reference the VPC elsewhere (such as in the [serverless-aur
         memory: number;
         public: boolean; //Will it be facing internet? This affects directly what security groups will be auto created
         port: number; // docker port (the port exposed on the docker image) - if not specified random port will be used - usefull for busy private subnets 
+        disableELB?: boolean; //useful for disabling ELB listeners on a cluster that has ELB and more tasks with ELB enabled
         entryPoint: string[]; // same as docker's entry point
         environment: { [key: string]: string }; // environment variables passed to docker container
         protocols: Array<{
@@ -61,7 +62,7 @@ If you would like to reference the VPC elsewhere (such as in the [serverless-aur
         imageRepository?: string; // image repository (used if image option is not provided)
         imageTag?: string; // image tag (used if image option is not provided)
         priority?: number; // priority for routing, defaults to 1
-        path?: string; // path the Load Balancer should send traffic to, defaults to '*'
+        path?: string | { path: string, method?: string }[]; // path the LB should send traffic to, defaults '*' (everything) - keyword 'ANY' is allowed on method
         desiredCount?: number; // number of tasks wanted by default - if not specified defaults to 1
         taskRoleArn?: string;
         healthCheckUri?: string; // defaults to "/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ikonintegration/serverless-fargate-plugin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A simple plugin to stand up an ECS FARGATE Cluster with a couple of services.",
   "main": "index.js",
   "homepage": "https://github.com/honerlaw/serverless-fargate-plugin/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "serverless-fargate-plugin",
-  "version": "1.0.63",
+  "name": "@ikonintegration/serverless-fargate-plugin",
+  "version": "1.2.0",
   "description": "A simple plugin to stand up an ECS FARGATE Cluster with a couple of services.",
   "main": "index.js",
   "homepage": "https://github.com/honerlaw/serverless-fargate-plugin/issues",

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ class ServerlessFargatePlugin {
                     vpc.getOutputs(),
                     cluster.getOutputs()
                 );
-            }
+            } else console.info('serverless-fargate-plugin: skipping cluster creation, missing informations (check required VPC).');
         }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ class ServerlessFargatePlugin {
         const service: any = this.serverless.service;
         const options: IClusterOptions[] = service.custom.fargate;
         const stage: string = service.provider ? service.provider.stage : service.stage;
+        const serviceName: string = service.service;
         
         //No cluster section specified, don't process
         if (!options || !options.length) {
@@ -30,7 +31,7 @@ class ServerlessFargatePlugin {
             if (clusterOption && clusterOption.vpc) { //sanity check for empty objects
                 //multiple self-created VPCs will be a problem here, TODO: solve this with cluster prefix on resouces
                 const vpc: VPC = new VPC(stage, clusterOption.vpc, clusterOption.tags);
-                const cluster: Cluster = new Cluster(stage, clusterOption, vpc, clusterOption.tags);
+                const cluster: Cluster = new Cluster(stage, clusterOption, vpc, serviceName, clusterOption.tags);
 
                 // merge current cluster stuff into resources
                 Object.assign(

--- a/src/options.ts
+++ b/src/options.ts
@@ -46,13 +46,14 @@ export interface IServiceOptions {
     memory: number;
     port?: number; // docker port (the port exposed on the docker image) - if not specified random port will be used - usefull for busy private subnets 
     entryPoint: string[]; //custom container entry point
+    disableELB?: boolean; //useful for disabling ELB listeners on a cluster that has ELB and more tasks with ELB enabled
     environment: { [key: string]: string };
     protocols: IServiceProtocolOptions[];
     image?: string;
     imageRepository?: string;
     imageTag?: string;
     priority?: number; // priority for routing, defaults to 1
-    path?: string; // path the LB should send traffic to, defaults '*' (everything)
+    path?: string | { path: string, method?: string }[]; // path the LB should send traffic to, defaults '*' (everything)
     desiredCount?: number; // defaults to 1
     autoScale?: IServiceAutoScalingOptions;
     taskRoleArn?: string;

--- a/src/options.ts
+++ b/src/options.ts
@@ -63,6 +63,7 @@ export interface IServiceOptions {
 
 export interface IClusterOptions {
     public: boolean;
+    disableELB?: boolean;
     clusterName: string;
     executionRoleArn?: string; // role for services, generated if not specfied
     vpc: IVPCOptions;

--- a/src/options.ts
+++ b/src/options.ts
@@ -45,7 +45,7 @@ export interface IServiceOptions {
     cpu: number;
     memory: number;
     port?: number; // docker port (the port exposed on the docker image) - if not specified random port will be used - usefull for busy private subnets 
-    entryPoint: string[];
+    entryPoint: string[]; //custom container entry point
     environment: { [key: string]: string };
     protocols: IServiceProtocolOptions[];
     image?: string;

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -52,15 +52,18 @@ export abstract class Resource<T> {
             }));
         } return null;
     }
+    public hasTags(): boolean { 
+        return (this.tags && Object.keys(this.tags).length > 0);
+    }
 
     public abstract generate(): any;
     public abstract getOutputs(): any;
 
     public getName(namePostFix: NamePostFix): string {
         if (this.namePrefix) {
-            return this.namePrefix + namePostFix.toString();
+            return (this.namePrefix + namePostFix.toString()).substr(0,32);
         }
-        return namePostFix + this.stage;
+        return (namePostFix + this.stage).substr(0, 32);
     }
 
     public getOptions(): T {

--- a/src/resources/cluster.ts
+++ b/src/resources/cluster.ts
@@ -1,19 +1,24 @@
 import { IClusterOptions, IServiceOptions} from "../options";
 import {VPC} from "./vpc";
 import {Service} from "./service";
+import {LoadBalancer} from './loadBalancer';
 import {NamePostFix, Resource} from "../resource";
 
 export class Cluster extends Resource<IClusterOptions> {
 
     private readonly vpc: VPC;
-    private readonly services: Service[];
+    public readonly services: Service[];
+    public readonly loadBalancer: LoadBalancer;
+    public readonly serviceName: string;
 
-    public constructor(stage: string, options: IClusterOptions, vpc: VPC, tags?: object) {
-        super(options, stage, `ECS${options.clusterName}`, tags);
+    public constructor(stage: string, options: IClusterOptions, vpc: VPC, serviceName: string, tags?: object) {
+        super(options, stage, `${serviceName}${options.clusterName}`, tags);
         this.vpc = vpc;
+        this.serviceName = serviceName;
         this.services = this.options.services.map((serviceOptions: IServiceOptions): any => {
             return new Service(this.stage, serviceOptions, this, tags);
         });
+        this.loadBalancer = new LoadBalancer(stage, options, this, tags);
     }
 
     public getExecutionRoleArn(): string | undefined {
@@ -21,7 +26,9 @@ export class Cluster extends Resource<IClusterOptions> {
     }
 
     public getOutputs(): any {
-        let outputs = {};
+        let outputs = {
+            ...this.loadBalancer.getOutputs()
+        };
         this.services.forEach((service: Service) => {
             outputs = {
                 ...outputs,
@@ -49,38 +56,13 @@ export class Cluster extends Resource<IClusterOptions> {
                 "Type": "AWS::ECS::Cluster",
                 "DeletionPolicy": "Delete",
                 "Properties": {
+                    "ClusterName": this.getName(NamePostFix.CLUSTER),
                     ...(this.getTags() ? { "Tags": this.getTags() } : {}),
                 }
             },
             ...this.getClusterSecurityGroups(),
-            ...(this.options.disableELB ? {} : {
-                [this.getName(NamePostFix.LOAD_BALANCER)]: {
-                    "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
-                    "DeletionPolicy": "Delete",
-                    "Properties": {
-                        ...(this.getTags() ? { "Tags": this.getTags() } : {}),
-                        "Scheme": (this.isPublic() ? "internet-facing" : "internal"),
-                        "LoadBalancerAttributes": [
-                            {
-                                "Key": "idle_timeout.timeout_seconds",
-                                "Value": "30"
-                            }
-                        ],
-                        "Subnets": this.getVPC().getSubnets(),
-                        "SecurityGroups": this.getELBSecurityGroups()
-                    },
-                }
-            }),
+            ...this.loadBalancer.generate(),
         }, ...defs);
-    }
-
-
-    /* Security groups -- this pontetially could be moved to another class */
-
-    private getELBSecurityGroups(): any {;
-        if (this.getVPC().useExistingVPC()) {
-            return this.getVPC().getSecurityGroups()
-        } return this.services.map((service: Service) => ({ "Ref": this.getSecurityGroupNameByService(service) }));
     }
 
     private getClusterSecurityGroups(): any {
@@ -109,66 +91,8 @@ export class Cluster extends Resource<IClusterOptions> {
                             "Ref": this.getName(NamePostFix.CONTAINER_SECURITY_GROUP)
                         }
                     }
-                },
-                ...this.generateServicesSecurityGroups()
-            };
-        }
-    }
-
-    private getSecurityGroupNameByService(service: Service): string {
-        return `${this.getName(NamePostFix.LOAD_BALANCER_SECURITY_GROUP)}_${service.getName(NamePostFix.SERVICE)}`;
-    }
-    
-    private generateServicesSecurityGroups(): object {
-        let secGroups = {};
-        this.services.forEach( (service: Service) => {
-            secGroups = {
-                ...secGroups,
-                ...this.generateSecurityGroupsByService(service)
-            };
-        });
-        return secGroups;
-
-    }
-
-    private generateSecurityGroupsByService(service: Service): any {
-        const ELBServiceSecGroup = this.getSecurityGroupNameByService(service);
-        return {
-            //Public security groups
-            ...(this.options.public ? {
-                [ELBServiceSecGroup]: {
-                    "Type": "AWS::EC2::SecurityGroup",
-                    "DeletionPolicy": "Delete",
-                    "Properties": {
-                        ...(this.getTags() ? { "Tags": this.getTags() } : {}),
-                        "GroupDescription": `Access to the public facing load balancer - task ${service.getName(NamePostFix.SERVICE)}`,
-                        "VpcId": this.getVPC().getRefName(),
-                        "SecurityGroupIngress": [
-                            {
-                                "CidrIp": "0.0.0.0/0",
-                                "IpProtocol": -1,
-                                "toPort": service.port
-                            }
-                        ]
-                    }
-                },
-                [this.getName(NamePostFix.SECURITY_GROUP_INGRESS_ALB)]: {
-                    "Type": "AWS::EC2::SecurityGroupIngress",
-                    "DeletionPolicy": "Delete",
-                    "Properties": {
-                        "Description": `Ingress from the ALB - task ${service.getName(NamePostFix.SERVICE)}`,
-                        "GroupId": {
-                            "Ref": this.getName(NamePostFix.CONTAINER_SECURITY_GROUP)
-                        },
-                        "IpProtocol": -1,
-                        "SourceSecurityGroupId": {
-                            "Ref": ELBServiceSecGroup
-                        }
-                    }
                 }
-            } : {
-                /*TODO: if not public AND also not specifiying a VPC, different secgroup must be created*/
-            })
+            };
         }
     }
 }

--- a/src/resources/cluster.ts
+++ b/src/resources/cluster.ts
@@ -53,22 +53,24 @@ export class Cluster extends Resource<IClusterOptions> {
                 }
             },
             ...this.getClusterSecurityGroups(),
-            [this.getName(NamePostFix.LOAD_BALANCER)]: {
-                "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
-                "DeletionPolicy": "Delete",
-                "Properties": {
-                    ...(this.getTags() ? { "Tags": this.getTags() } : {}),
-                    "Scheme": (this.isPublic() ? "internet-facing" : "internal"),
-                    "LoadBalancerAttributes": [
-                        {
-                            "Key": "idle_timeout.timeout_seconds",
-                            "Value": "30"
-                        }
-                    ],
-                    "Subnets": this.getVPC().getSubnets(),
-                    "SecurityGroups": this.getELBSecurityGroups()
-                },
-            },
+            ...(this.options.disableELB ? {} : {
+                [this.getName(NamePostFix.LOAD_BALANCER)]: {
+                    "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+                    "DeletionPolicy": "Delete",
+                    "Properties": {
+                        ...(this.getTags() ? { "Tags": this.getTags() } : {}),
+                        "Scheme": (this.isPublic() ? "internet-facing" : "internal"),
+                        "LoadBalancerAttributes": [
+                            {
+                                "Key": "idle_timeout.timeout_seconds",
+                                "Value": "30"
+                            }
+                        ],
+                        "Subnets": this.getVPC().getSubnets(),
+                        "SecurityGroups": this.getELBSecurityGroups()
+                    },
+                }
+            }),
         }, ...defs);
     }
 

--- a/src/resources/loadBalancer.ts
+++ b/src/resources/loadBalancer.ts
@@ -1,0 +1,178 @@
+import { IClusterOptions, IServiceOptions} from "../options";
+import {VPC} from "./vpc";
+import {Service} from "./service";
+import {NamePostFix, Resource} from "../resource";
+import {Cluster} from './cluster';
+import { Protocol } from "./protocol";
+
+export class LoadBalancer extends Resource<IClusterOptions> {
+
+    private readonly cluster: Cluster;
+
+    public constructor(stage: string, options: IClusterOptions, cluster: Cluster, tags?: object) {
+        super(options, stage, `${cluster.serviceName}${options.clusterName}`, tags);
+        this.cluster = cluster;
+    }
+
+    public getOutputs(): any { return {}; }
+
+    public generate(): any {
+        return Object.assign({
+            ...(this.options.disableELB ? {} : {
+                [this.getName(NamePostFix.LOAD_BALANCER)]: {
+                    "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+                    "DeletionPolicy": "Delete",
+                    "Properties": {
+                        "Name": this.getName(NamePostFix.LOAD_BALANCER),
+                        ...(this.getTags() ? { "Tags": this.getTags() } : {}),
+                        "Scheme": (this.cluster.isPublic() ? "internet-facing" : "internal"),
+                        "LoadBalancerAttributes": [
+                            {
+                                "Key": "idle_timeout.timeout_seconds",
+                                "Value": "30"
+                            }
+                        ],
+                        "Subnets": this.cluster.getVPC().getSubnets(),
+                        "SecurityGroups": this.getELBSecurityGroupsRef()
+                    },
+                },
+                ...this.getServicesSecurityGroups(),
+                ...this.getListeners(),
+            }),
+        });
+    }
+
+
+    /* Security groups */
+    private getELBSecurityGroupsRef(): any {;
+        if (this.cluster.getVPC().useExistingVPC()) {
+            return this.cluster.getVPC().getSecurityGroups()
+        } else {
+            let secGroups = [];
+            this.cluster.services.forEach((service: Service) => {
+                if (this.options.public && !service.getOptions().disableELB) {
+                    secGroups.push({ "Ref": this.getSecurityGroupNameByService(service) });
+                }
+            });
+            return secGroups;
+        }
+    }
+
+    private getSecurityGroupNameByService(service: Service): string {
+        return `${this.getName(NamePostFix.LOAD_BALANCER_SECURITY_GROUP)}${service.getName(NamePostFix.SERVICE)}`;
+    }
+    
+    private getServicesSecurityGroups(): object {
+        let secGroups = {};
+        this.cluster.services.forEach( (service: Service) => {
+            secGroups = {
+                ...secGroups,
+                ...this.generateSecurityGroupsByService(service)
+            };
+        });
+        return secGroups;
+    }
+
+    private generateSecurityGroupsByService(service: Service): any {
+        const ELBServiceSecGroup = this.getSecurityGroupNameByService(service);
+        return {
+            //Public security groups
+            ...(this.options.public && !service.getOptions().disableELB ? {
+                [ELBServiceSecGroup]: {
+                    "Type": "AWS::EC2::SecurityGroup",
+                    "DeletionPolicy": "Delete",
+                    "Properties": {
+                        ...(this.getTags() ? { "Tags": this.getTags() } : {}),
+                        "GroupName": ELBServiceSecGroup,
+                        "GroupDescription": `Access to the public facing load balancer - task ${service.getName(NamePostFix.SERVICE)}`,
+                        "VpcId": this.cluster.getVPC().getRefName(),
+                        "SecurityGroupIngress": [
+                            {
+                                "CidrIp": "0.0.0.0/0",
+                                // ...(service.port ? {
+                                //     "IpProtocol": 'tcp',
+                                //     "toPort": service.port,
+                                //     "fromPort": service.port
+                                // } : {
+                                    
+                                // })
+                                "IpProtocol": -1
+                            }
+                        ]
+                    }
+                },
+                [ELBServiceSecGroup + this.getName(NamePostFix.SECURITY_GROUP_INGRESS_ALB)]: {
+                    "Type": "AWS::EC2::SecurityGroupIngress",
+                    "DeletionPolicy": "Delete",
+                    "Properties": {
+                        "Description": `Ingress from the ALB - task ${service.getName(NamePostFix.SERVICE)}`,
+                        "GroupId": {
+                            "Ref": this.cluster.getName(NamePostFix.CONTAINER_SECURITY_GROUP)
+                        },
+                        "IpProtocol": -1,
+                        "SourceSecurityGroupId": {
+                            "Ref": ELBServiceSecGroup
+                        }
+                    }
+                }
+            } : {
+                /*TODO: if not public AND also not specifiying a VPC, different secgroup must be created*/
+            })
+        }
+    }
+
+    /* Elastic Load Balance -- this should be moved to ELB class when implemented */
+    private getListeners(): any {
+        const aggServices = this.getAggregatedServices();
+        let listeners = {};
+        Object.keys(aggServices).forEach( (listenerKey) => {
+            const listener = aggServices[listenerKey];
+            const defaultService = listener.services[0];
+            listeners = {
+                ...listeners,
+                [this.getName(NamePostFix.LOAD_BALANCER_LISTENER)+listener.proto.port]: {
+                    "Type": "AWS::ElasticLoadBalancingV2::Listener",
+                    "DeletionPolicy": "Delete",
+                    "DependsOn": [
+                        this.getName(NamePostFix.LOAD_BALANCER)
+                    ],
+                    "Properties": {
+                        "DefaultActions": [{ //Note: this is just the default, no biggie
+                            "TargetGroupArn": {
+                                "Ref": defaultService.getName(NamePostFix.TARGET_GROUP)
+                            },
+                            "Type": "forward"
+                        }],
+                        "LoadBalancerArn": {
+                            "Ref": this.getName(NamePostFix.LOAD_BALANCER)
+                        },
+                        "Port": listener.proto.port,
+                        "Protocol": listener.proto.getOptions().protocol,
+                        ...(listener.proto.getOptions().protocol == "HTTPS" ? {
+                            "Certificates": listener.proto.getOptions().certificateArn.map((certificateArn: string): any => ({
+                                "CertificateArn": certificateArn
+                            }))} : {}
+                        )
+                    }
+                }
+            };
+        });
+        return listeners;
+    }
+    private getAggregatedServices(): any {
+        //Sanity check -- check if have more than one service listening for the same port, but different protocol
+        //This is not allowed, better to explicty deny it rather than creating confusion os misconfigured systems
+        let mappings = {};
+        for (let service of this.cluster.services) {
+            for (let proto of service.protocols) {
+                if (mappings[proto.port]) {
+                    if (mappings[proto.port].proto.getOptions().protocol != proto.getOptions().protocol) {
+                        throw new Error(`Serverless: fargate-plugin: Service ${service.getOptions().name} on cluster ${this.cluster.getName(NamePostFix.CLUSTER)}, protocol ${proto.getOptions().protocol} is colliding with different service at same cluster on port ${proto.port}. Can't continue!`);
+                    }
+                    mappings[proto.port].services.push(service);
+                } else mappings[proto.port] = { proto, services: [service]};
+            }
+        }
+        return mappings;
+    }
+}

--- a/src/resources/protocol.ts
+++ b/src/resources/protocol.ts
@@ -53,11 +53,10 @@ export class Protocol extends Resource<IServiceProtocolOptions> {
 
     public generate(): any {
         if (this.cluster.getOptions().disableELB) return {};
-        //
         if (this.options.protocol === "HTTPS" && (!this.options.certificateArns || this.options.certificateArns.length === 0)) {
             throw new Error('Certificate ARN required for HTTPS');
         }
-        //
+
         var def: any = {
             [this.getName(NamePostFix.LOAD_BALANCER_LISTENER)]: {
                 "Type": "AWS::ElasticLoadBalancingV2::Listener",

--- a/src/resources/protocol.ts
+++ b/src/resources/protocol.ts
@@ -3,24 +3,22 @@ import {IServiceProtocolOptions} from "../options";
 import {Service} from "./service";
 import {Cluster} from "./cluster";
 
-const PORT_MAP: { [key: string]: number } = {
-    "HTTP": 80,
-    "HTTPS": 443
-};
-
 export class Protocol extends Resource<IServiceProtocolOptions> {
 
     private readonly cluster: Cluster;
     private readonly service: Service;
+    public readonly port: number;
 
     public constructor(cluster: Cluster,
                        service: Service,
                        stage: string,
                        options: IServiceProtocolOptions, 
+                       port: number,
                        tags?: object) {
         super(options, stage, service.getNamePrefix(), tags);
         this.cluster = cluster;
         this.service = service;
+        this.port = port;
     }
 
     public getName(namePostFix: NamePostFix): string {
@@ -28,7 +26,7 @@ export class Protocol extends Resource<IServiceProtocolOptions> {
     }
 
     public getOutputs(): any {
-        if (this.cluster.getOptions().disableELB) return {};
+        if (this.cluster.getOptions().disableELB || this.service.getOptions().disableELB) return {};
         return {
             [this.cluster.getName(NamePostFix.CLUSTER) + this.service.getName(NamePostFix.SERVICE) + this.options.protocol]: {
                 "Description": "Elastic load balancer service endpoint",
@@ -41,9 +39,9 @@ export class Protocol extends Resource<IServiceProtocolOptions> {
                         [
                             this.options.protocol.toLowerCase(),
                             "://",
-                            { "Fn::GetAtt": [this.cluster.getName(NamePostFix.LOAD_BALANCER), "DNSName"] },
+                            { "Fn::GetAtt": [this.cluster.loadBalancer.getName(NamePostFix.LOAD_BALANCER), "DNSName"] },
                             ":",
-                            this.service.port 
+                            this.port 
                         ]
                     ]
                 }
@@ -52,35 +50,45 @@ export class Protocol extends Resource<IServiceProtocolOptions> {
     }
 
     public generate(): any {
-        if (this.cluster.getOptions().disableELB) return {};
+        if (this.cluster.getOptions().disableELB || this.service.getOptions().disableELB) return {};
         if (this.options.protocol === "HTTPS" && (!this.options.certificateArns || this.options.certificateArns.length === 0)) {
             throw new Error('Certificate ARN required for HTTPS');
         }
-
-        var def: any = {
-            [this.getName(NamePostFix.LOAD_BALANCER_LISTENER)]: {
-                "Type": "AWS::ElasticLoadBalancingV2::Listener",
-                "DeletionPolicy": "Delete",
-                "DependsOn": [
-                    this.cluster.getName(NamePostFix.LOAD_BALANCER)
-                ],
-                "Properties": {
-                    "DefaultActions": [
-                        {
-                            "TargetGroupArn": {
-                                "Ref": this.service.getName(NamePostFix.TARGET_GROUP)
-                            },
-                            "Type": "forward"
-                        }
-                    ],
-                    "LoadBalancerArn": {
-                        "Ref": this.cluster.getName(NamePostFix.LOAD_BALANCER)
-                    },
-                    "Port": this.service.port,
-                    "Protocol": this.options.protocol
-                }
-            },
-            [this.getName(NamePostFix.LOAD_BALANCER_LISTENER_RULE)]: {
+        return this.getListenerRules();
+    }
+    public getListenerRulesName(): string[] {
+        if (typeof this.service.getOptions().path === 'string') {
+            return [`${this.getName(NamePostFix.LOAD_BALANCER_LISTENER_RULE)}${0}`];
+        } else if (Array.isArray(this.service.getOptions().path)) {
+            const rules: any = this.service.getOptions().path;
+            return rules.map((p, index) => {
+                return `${this.getName(NamePostFix.LOAD_BALANCER_LISTENER_RULE)}${index}`;
+            });
+        } else {
+            return [`${this.getName(NamePostFix.LOAD_BALANCER_LISTENER_RULE)}${0}`];
+        }
+    }
+    protected getListenerRules(): any {
+        if (typeof this.service.getOptions().path === 'string') {
+            const path: any = this.service.getOptions().path;
+            return this.generateListenerRule(path, 0);
+        } else if (Array.isArray(this.service.getOptions().path)) {
+            const rules: any = this.service.getOptions().path;
+            let _retRules = {};
+            rules.forEach((p, index) => {
+                _retRules = {
+                    ..._retRules,
+                    ...this.generateListenerRule(p.path, index, p.method)
+                };
+            });
+            return _retRules;
+        } else {
+            return this.generateListenerRule('*', 0);
+        }
+    }
+    private generateListenerRule(path: string, index: number, method?: string): any {
+        return {
+            [`${this.getName(NamePostFix.LOAD_BALANCER_LISTENER_RULE)}${index}`]: {
                 "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
                 "DeletionPolicy": "Delete",
                 "Properties": {
@@ -93,25 +101,22 @@ export class Protocol extends Resource<IServiceProtocolOptions> {
                     "Conditions": [
                         {
                             "Field": "path-pattern",
-                            "Values": [this.service.getOptions().path ? this.service.getOptions().path : '*']
-                        }
+                            "Values": [path]
+                        },
+                        ...(method && method != '*' && method != 'ANY' ? [{
+                            "Field": "http-request-method",
+                            "HttpRequestMethodConfig": { "Values": [method] }
+                        }] : [{}])
                     ],
                     "ListenerArn": {
-                        "Ref": this.getName(NamePostFix.LOAD_BALANCER_LISTENER)
+                        "Ref": this.cluster.loadBalancer.getName(NamePostFix.LOAD_BALANCER_LISTENER) + this.port
                     },
-                    "Priority": this.service.getOptions().priority ? this.service.getOptions().priority : 1
+                    // increase priority if have more than one handler -- todo: find a way to follow user dictated
+                    // priority while not reusing priority for the same service but different rules.
+                    "Priority": (this.service.getOptions().priority ? this.service.getOptions().priority : 1) + index
                 }
             }
-        };
-
-        if (this.options.protocol === "HTTPS") {
-            def[this.getName(NamePostFix.LOAD_BALANCER_LISTENER)].Properties.Certificates = this.options
-                .certificateArns.map((certificateArn: string): any => ({
-                    "CertificateArn": certificateArn
-                }));
         }
-
-        return def;
     }
 
 }

--- a/src/resources/protocol.ts
+++ b/src/resources/protocol.ts
@@ -78,7 +78,7 @@ export class Protocol extends Resource<IServiceProtocolOptions> {
             rules.forEach((p, index) => {
                 _retRules = {
                     ..._retRules,
-                    ...this.generateListenerRule(p.path, index, p.method)
+                    ...this.generateListenerRule((p.path || p), index, p.method)
                 };
             });
             return _retRules;

--- a/src/resources/protocol.ts
+++ b/src/resources/protocol.ts
@@ -28,6 +28,7 @@ export class Protocol extends Resource<IServiceProtocolOptions> {
     }
 
     public getOutputs(): any {
+        if (this.cluster.getOptions().disableELB) return {};
         return {
             [this.cluster.getName(NamePostFix.CLUSTER) + this.service.getName(NamePostFix.SERVICE) + this.options.protocol]: {
                 "Description": "Elastic load balancer service endpoint",
@@ -51,10 +52,12 @@ export class Protocol extends Resource<IServiceProtocolOptions> {
     }
 
     public generate(): any {
+        if (this.cluster.getOptions().disableELB) return {};
+        //
         if (this.options.protocol === "HTTPS" && (!this.options.certificateArns || this.options.certificateArns.length === 0)) {
             throw new Error('Certificate ARN required for HTTPS');
         }
-
+        //
         var def: any = {
             [this.getName(NamePostFix.LOAD_BALANCER_LISTENER)]: {
                 "Type": "AWS::ElasticLoadBalancingV2::Listener",

--- a/src/resources/service.ts
+++ b/src/resources/service.ts
@@ -83,8 +83,7 @@ export class Service extends Resource<IServiceOptions> {
                     "DesiredCount": this.options.desiredCount ? this.options.desiredCount : 1,
                     "NetworkConfiguration": {
                         "AwsvpcConfiguration": {
-                            /* cluster can be public, but the service is not binded to ELB, don't assign public IP*/
-                            "AssignPublicIp": (this.cluster.isPublic() && !this.options.disableELB ? "ENABLED" : "DISABLED"),
+                            "AssignPublicIp": (this.cluster.isPublic() ? "ENABLED" : "DISABLED"),
                             "SecurityGroups": this.getSecurityGroups(),
                             "Subnets": this.cluster.getVPC().getSubnets()
                         }

--- a/src/resources/service.ts
+++ b/src/resources/service.ts
@@ -76,6 +76,7 @@ export class Service extends Resource<IServiceOptions> {
                         "Ref": this.cluster.getName(NamePostFix.CLUSTER)
                     },
                     ...(this.getTags() ? { "Tags": this.getTags() } : {}),
+                    "EnableECSManagedTags": true,
                     "LaunchType": "FARGATE",
                     "DeploymentConfiguration": {
                         "MaximumPercent": 200,

--- a/src/resources/service.ts
+++ b/src/resources/service.ts
@@ -152,7 +152,7 @@ export class Service extends Resource<IServiceOptions> {
                         this.options.environment && {
                             "Environment": Object.keys(this.options.environment).map(name => ({
                                 "Name": name,
-                                "Value": String(this.options.environment[name]),
+                                "Value": this.options.environment[name],
                             }))
                         })
                     ]

--- a/src/resources/service.ts
+++ b/src/resources/service.ts
@@ -24,10 +24,9 @@ export class Service extends Resource<IServiceOptions> {
         //
         super(options, stage, safeResourceName, tags); 
         this.cluster = cluster;
-
-        this.protocols = this.options.protocols.map((serviceProtocolOptions: IServiceProtocolOptions): any => {
+        this.protocols = (this.cluster.getOptions().disableELB ? [] : this.options.protocols.map((serviceProtocolOptions: IServiceProtocolOptions): any => {
             return new Protocol(cluster, this, stage, serviceProtocolOptions, tags);
-        });
+        }));
 
         this.logGroupName = `serverless-fargate-${options.name}-${stage}-${uuid()}`;
 
@@ -66,8 +65,10 @@ export class Service extends Resource<IServiceOptions> {
             [this.getName(NamePostFix.SERVICE)]: {
                 "Type": "AWS::ECS::Service",
                 "DeletionPolicy": "Delete",
-                "DependsOn": this.protocols.map((protocol: Protocol): string => {
-                    return protocol.getName(NamePostFix.LOAD_BALANCER_LISTENER_RULE)
+                ...(this.cluster.getOptions().disableELB ? {} : {
+                    "DependsOn": this.protocols.map((protocol: Protocol): string => {
+                        return protocol.getName(NamePostFix.LOAD_BALANCER_LISTENER_RULE)
+                    }),
                 }),
                 "Properties": {
                     "ServiceName": this.options.name,
@@ -91,15 +92,17 @@ export class Service extends Resource<IServiceOptions> {
                     "TaskDefinition": {
                         "Ref": this.getName(NamePostFix.TASK_DEFINITION)
                     },
-                    "LoadBalancers": [
-                        {
-                            "ContainerName": this.getName(NamePostFix.CONTAINER_NAME),
-                            "ContainerPort": this.port,
-                            "TargetGroupArn": {
-                                "Ref": this.getName(NamePostFix.TARGET_GROUP)
+                    ...(this.cluster.getOptions().disableELB ? {} : {
+                        "LoadBalancers": [
+                            {
+                                "ContainerName": this.getName(NamePostFix.CONTAINER_NAME),
+                                "ContainerPort": this.port,
+                                "TargetGroupArn": {
+                                    "Ref": this.getName(NamePostFix.TARGET_GROUP)
+                                }
                             }
-                        }
-                    ]
+                        ]
+                    })
                 }
             },
         };
@@ -159,6 +162,7 @@ export class Service extends Resource<IServiceOptions> {
     }
 
     private generateTargetGroup(): any {
+        if (this.cluster.getOptions().disableELB) return {};
         return {
             [this.getName(NamePostFix.TARGET_GROUP)]: {
                 "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",


### PR DESCRIPTION
Sorry for the 'compressed' commit, had to squash some due privacy concerns. 

- Fix: Issue with multiple tasks not having ELB ingress group set 
- Fix: Issue related to service ingress sec. group not accepting ports when public 
- Improvement: Create ELB object, handle listeners for different tasks using the same port w/ priority 
- Improvement: Use one exposed port on task to receive multiple protocols 
- Improvement: Improve support to non-exposed tasks (remove port bind from container, ...)
- Improvement: Add resource name on ELB, Cluster and others - Prefix resources with service name
- Improvement: sanitize resources names by limiting to 32 chars
- Change: Remove '-' notation 
- Feature: Add option to disable ELB on a specific task 
- Feature: Add option to specify multiple paths and methods for each task
- Feature: Explicitly ask for ECS managed tasks feature when using it.