### PR TITLE
Use clusterName or serviceName for cluster namePrefix

### DIFF
--- a/src/resources/cluster.ts
+++ b/src/resources/cluster.ts
@@ -12,7 +12,13 @@ export class Cluster extends Resource<IClusterOptions> {
     public readonly serviceName: string;
 
     public constructor(stage: string, options: IClusterOptions, vpc: VPC, serviceName: string, tags?: object) {
-        super(options, stage, `${serviceName}${options.clusterName}`, tags);
+        let namePrefix: string;
+        if (typeof options.clusterName === "undefined") {
+            namePrefix = serviceName;
+        } else {
+            namePrefix = options.clusterName;
+        }
+        super(options, stage, namePrefix, tags);
         this.vpc = vpc;
         this.serviceName = serviceName;
         this.services = this.options.services.map((serviceOptions: IServiceOptions): any => {


### PR DESCRIPTION
Quick change related to #16 but not exactly an implementation that adds any new options (yet).  Rather than add a new option for an optional prefix, it assumes that when the `clusterName` is explicitly defined, the user has access to any and all other pieces of the serverless parameters that they can use for prefix values explicitly in the `clusterName` option, e.g.

```
service: my-cool-stuff
custom:
  fargate:
    - clusterName: ${self:service}
```

As it is without this PR, that would result in effectively "my-cool-stuffmy-cool-stuffCluster" (truncated to 32 chars; BTW, why truncate to 32 chars?).  It would be cool to apply some serverless naming conventions for resources like a fargate cluster but I'm not exactly sure how that would be done, i.e.
- https://www.serverless.com/framework/docs/providers/aws/guide/resources#aws-cloudformation-resource-reference

> We're also using the term 'normalizedName' or similar terms in this guide. This means dropping any characters that aren't allowed in resources names, e.g. special characters.

An example of similar issues/fixes might be found in
- https://github.com/silvermine/serverless-plugin-external-sns-events/pull/16
- https://github.com/serverless/serverless/blob/master/lib/plugins/aws/lib/naming.js

It might be better, as a whole, to rename this option as `clusterNamePrefix` because it also gets a suffix i.e. `Cluster`, but that change is not made in this brief change.