### PR TITLE
Add ability to opt out of service-name prefix for cluster

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -65,6 +65,7 @@ export interface IServiceOptions {
 export interface IClusterOptions {
     public: boolean;
     disableELB?: boolean;
+    prefixWithServiceName?: boolean;
     clusterName: string;
     executionRoleArn?: string; // role for services, generated if not specfied
     vpc: IVPCOptions;

--- a/src/resources/cluster.ts
+++ b/src/resources/cluster.ts
@@ -12,7 +12,12 @@ export class Cluster extends Resource<IClusterOptions> {
     public readonly serviceName: string;
 
     public constructor(stage: string, options: IClusterOptions, vpc: VPC, serviceName: string, tags?: object) {
-        super(options, stage, `${serviceName}${options.clusterName}`, tags);
+        // Default to prefixing with service name for backwards-compatability
+        let resourceName = options.prefixWithServiceName === false
+            ? options.clusterName
+            : `${serviceName}${options.clusterName}`;
+
+        super(options, stage, resourceName, tags);
         this.vpc = vpc;
         this.serviceName = serviceName;
         this.services = this.options.services.map((serviceOptions: IServiceOptions): any => {


### PR DESCRIPTION
As noted in https://github.com/honerlaw/serverless-fargate-plugin/issues/16 service names are allowed to contain dashes but resource names must be strictly alphanumeric, causing invalid cluster resource names for any dasherized-services.

This pull request adds the ability to opt out of the auto-prefix via `prefixWithServiceName: false` in the configuration. By default (ie. omitting the key), it will continue to prefix as before for backwards compatibility. Otherwise resource names would change for existing stacks.